### PR TITLE
Fixed API room call

### DIFF
--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -55,7 +55,7 @@ export class RoomsService {
   }
 
   findOne(id: string) {
-    this.rooms.find((room) => room.roomNumber === id);
+    return this.rooms.find((room) => room.roomNumber === id);
   }
 
   update(id: string, updateRoomDto: UpdateRoomDto) {


### PR DESCRIPTION
I was trying to fetch a room using the API. After a GET request to the following URL `api/rooms/1` , I realized that the response that I was getting was null. 

<img width="911" alt="before_fix" src="https://github.com/santoshyadavdev/hotelapi/assets/61521319/06f6b7d3-06ac-402c-81d6-2a75138a0393">

I took a look in the rooms controller and found the method that is responsible for the request above  

```ts
@Get(':id')
findOne(@Param('id') id: string) {
  return this.roomsService.findOne(id);
}
```

Upon inspection, I found out that in the `rooms.service.ts` , the method `findOne` , wasn't returning the result. Therefor, I added a return statement to it.

```ts
findOne(id: string) {
  return this.rooms.find((room) => room.roomNumber === id);
}
```

After testing it again, I finally have the correct result.

<img width="914" alt="after_fix" src="https://github.com/santoshyadavdev/hotelapi/assets/61521319/989b09a7-6ccf-4a9f-9bad-3f4a85ec7969">
